### PR TITLE
chore: add OPPO root beer checking

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -9,6 +9,7 @@ public class RootedCheck {
 
     private static final String ONEPLUS = "oneplus";
     private static final String MOTO = "moto";
+    private static final String OPPO = "oppo";
 
     /**
      * Checks if the device is rooted.
@@ -29,7 +30,7 @@ public class RootedCheck {
     private static boolean rootBeerCheck(Context context) {
         RootBeer rootBeer = new RootBeer(context);
         Boolean rv;
-        if(Build.BRAND.contains(ONEPLUS) || Build.BRAND.contains(MOTO)) {
+        if(Build.BRAND.contains(ONEPLUS) || Build.BRAND.contains(MOTO) || Build.BRAND.contains(OPPO)) {
             rv = rootBeer.isRootedWithoutBusyBoxCheck();
         } else {
             rv = rootBeer.isRooted();


### PR DESCRIPTION
Hi Jun Kai, we realize that some of the oppo users' devices is marked as rooted. This PR is to add OPPO devices to isRootedWithoutBusyBoxCheck checking block. Please kindly help us reviewed the code changes. Thank you!

reference:
https://github.com/scottyab/rootbeer#false-positives

![MicrosoftTeams-image](https://user-images.githubusercontent.com/44250267/137249781-6017997a-ef64-484e-9c7d-8728c11876d8.png)

